### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![smithery badge](https://smithery.ai/badge/@PhialsBasement/mcp-puppeteer-linux)](https://smithery.ai/server/@PhialsBasement/mcp-puppeteer-linux)
 A Model Context Protocol server that provides browser automation capabilities using Puppeteer, with full support for Linux display servers (X11 and Wayland). This server enables LLMs to interact with web pages, take screenshots, and execute JavaScript in a real browser environment.
 
+<a href="https://glama.ai/mcp/servers/dhm3zekwh9"><img width="380" height="200" src="https://glama.ai/mcp/servers/dhm3zekwh9/badge" alt="Puppeteer Linux Server MCP server" /></a>
+
 ## Display Server Support
 This fork adds automatic detection and configuration for Linux display servers:
 - Automatic X11/Wayland detection


### PR DESCRIPTION
This PR adds a badge for the [MCP Puppeteer Linux Server](https://glama.ai/mcp/servers/dhm3zekwh9) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/dhm3zekwh9"><img width="380" height="200" src="https://glama.ai/mcp/servers/dhm3zekwh9/badge" alt="Puppeteer Linux Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.